### PR TITLE
logic: don't error out if the Habitat object doesn't exist

### DIFF
--- a/pkg/broker/logic.go
+++ b/pkg/broker/logic.go
@@ -321,7 +321,7 @@ func (b *BrokerLogic) deleteResources(planID, instanceID string) error {
 	}
 
 	err = b.DeleteHabitat(name, ns)
-	if err != nil {
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return err
 	}
 


### PR DESCRIPTION
It might have been deleted before, just continue deleting resources.